### PR TITLE
fix: the parameter of deploy in Counter.ts

### DIFF
--- a/packages/hardhat/test/Counter.ts
+++ b/packages/hardhat/test/Counter.ts
@@ -7,7 +7,7 @@ describe("Counter", function () {
 
   before(async () => {
     const counterFactory = await ethers.getContractFactory("Counter");
-    counter = (await counterFactory.deploy()) as Counter;
+    counter = (await counterFactory.deploy(10)) as Counter;
     await counter.waitForDeployment();
   });
 


### PR DESCRIPTION
# fix: add missing constructor parameter to Counter contract deployment

## Description

Fixed the missing constructor parameter issue when deploying the Counter contract in `packages/hardhat/test/Counter.ts`.

**Problem:**
The original test code was deploying the Counter contract without providing the required constructor parameter:
```typescript
counter = (await counterFactory.deploy()) as Counter;
```

**Solution:**
After examining the `Counter.sol` contract's constructor, it requires a `uint _x` parameter to initialize the state variable `x`:
```solidity
constructor(uint _x) {
    x = _x;
}
```

Therefore, added the initial value parameter `10` in the test deployment:
```typescript
counter = (await counterFactory.deploy(10)) as Counter;
```

This fix ensures that the test can execute properly and the contract is deployed with an appropriate initial value.

## Additional Information

- [x] I have read the [contributing docs](/alchemyplatform/scaffold-alchemy/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/alchemyplatform/scaffold-alchemy/pulls)

## Related Issues

_Note: This is a small and straightforward bug fix that resolves a deployment parameter mismatch between the contract constructor and test deployment call._

Your ENS/address:
0xdb4101e7f5E2cC0e1A749092ff5287e3d36A5df6