### PR TITLE
Update solidity compiler to 0.8.28 in hardhat.config.ts

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -23,7 +23,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.20",
+        version: "0.8.28",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
Changes the default Solidity compiler version from 0.8.20 to 0.8.28 in `hardhat.config.ts`.

Reason: version 0.8.20 fails to download from solc-bin and triggers Hardhat error HH502 on some machines (rare)

Tested locally and compilation works fine with 0.8.28.
